### PR TITLE
Improve project discoverability

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+title: "GeneralTmm: General 4×4 Transfer-Matrix Method"
+message: "If you use this software, please cite it using the metadata from this file."
+type: software
+authors:
+  - given-names: Ardi
+    family-names: Loot
+    email: ardi.loot@outlook.com
+repository-code: "https://github.com/ardiloot/GeneralTmm"
+url: "https://pypi.org/project/GeneralTmm/"
+license: MIT
+keywords:
+  - transfer-matrix method
+  - optics
+  - thin film
+  - photonics
+  - anisotropic
+  - birefringence
+  - surface plasmon
+  - multilayer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,18 @@ requires-python = ">=3.10"
 authors = [
     { name = "Ardi Loot", email = "ardi.loot@outlook.com" },
 ]
+keywords = [
+    "optics",
+    "transfer-matrix",
+    "thin-film",
+    "photonics",
+    "plasmonics",
+    "anisotropic",
+    "birefringence",
+    "multilayer",
+    "SPP",
+    "TMM",
+]
 dynamic = ["version"]
 dependencies = [
     "numpy>=2.0",
@@ -24,8 +36,9 @@ dependencies = [
     "eigency>=2.0.0",
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -33,7 +46,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Programming Language :: C++",
+    "Programming Language :: Cython",
     "Topic :: Scientific/Engineering :: Physics",
+    "Topic :: Scientific/Engineering",
+    "Typing :: Typed",
 ]
 
 [project.optional-dependencies]
@@ -42,6 +58,8 @@ examples = ["matplotlib"]
 [project.urls]
 Homepage = "https://github.com/ardiloot/GeneralTmm"
 Repository = "https://github.com/ardiloot/GeneralTmm"
+Changelog = "https://github.com/ardiloot/GeneralTmm/releases"
+"Bug Tracker" = "https://github.com/ardiloot/GeneralTmm/issues"
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
## Summary

Improves how GeneralTmm surfaces in PyPI search, GitHub search, and academic citations — no code changes.

## Changes

### pyproject.toml
- **Keywords** — added 10 search terms (`optics`, `transfer-matrix`, `thin-film`, `photonics`, `plasmonics`, `anisotropic`, `birefringence`, `multilayer`, `SPP`, `TMM`)
- **Status** — bumped from `Beta` → `Production/Stable`
- **Classifiers** — added `OS Independent`, `Programming Language :: Cython`, `Topic :: Scientific/Engineering`, `Typing :: Typed`
- **Project URLs** — added Changelog (→ GitHub Releases) and Bug Tracker (→ Issues) for the PyPI sidebar

### CITATION.cff (new)
- Enables GitHub's **Cite this repository** button
- Contains author info, repo/PyPI URLs, license, and keywords

## Notes
These take effect on the next PyPI release. The CITATION.cff is live on GitHub as soon as this merges.